### PR TITLE
Cleanup screen results

### DIFF
--- a/lua/core/screen.lua
+++ b/lua/core/screen.lua
@@ -205,10 +205,11 @@ Screen.text_center = function(str) _norns.screen_text_center(str) end
 Screen.text_center_rotate = function(x, y, str, degrees) _norns.screen_text_center_rotate(x, y, str, degrees) end
 
 --- calculate width of text given current font and draw state.
--- completes asynchronousely via system callback
--- (FIXME: see screen.handle_text_extents() or whatever)
 -- @tparam string str : text to calculate width of
-Screen.text_extents = function(str) _norns.screen_text_extents(str) end
+Screen.text_extents = function(str) 
+  local w, h = _norns.screen_text_extents(str)
+  return w,h
+end
 
 -- get the current drawing position in the screen surface
 -- @treturn number x

--- a/lua/core/screen.lua
+++ b/lua/core/screen.lua
@@ -207,8 +207,7 @@ Screen.text_center_rotate = function(x, y, str, degrees) _norns.screen_text_cent
 --- calculate width of text given current font and draw state.
 -- @tparam string str : text to calculate width of
 Screen.text_extents = function(str) 
-  local w, h = _norns.screen_text_extents(str)
-  return w,h
+  return _norns.screen_text_extents(str)
 end
 
 -- get the current drawing position in the screen surface

--- a/lua/core/screen.lua
+++ b/lua/core/screen.lua
@@ -213,7 +213,7 @@ Screen.text_extents = function(str) _norns.screen_text_extents(str) end
 -- get the current drawing position in the screen surface
 -- @treturn number x
 -- @treturn number y
-Screen.current_point() = function() return _norns.screen_current_point() end
+Screen.current_point = function() return _norns.screen_current_point() end
 
 --- select font face.
 -- @param index font face (see list, or Screen.font_face_names)

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -93,9 +93,6 @@ typedef enum {
     // monome grid tilt
     EVENT_GRID_TILT,
     // screen asynchronous results callbacks
-    EVENT_SCREEN_RESULT_TEXT_EXTENTS,
-    EVENT_SCREEN_RESULT_CURRENT_POINT,
-    EVENT_SCREEN_RESULT_PEEK,
     EVENT_SCREEN_REFRESH,
 } event_t;
 
@@ -250,7 +247,7 @@ struct event_stat {
     uint8_t cpu2;
     uint8_t cpu3;
     uint8_t cpu4;
-};
+}; // +10
 
 struct event_enc {
     struct event_common common;
@@ -312,12 +309,12 @@ struct event_crow_event {
     struct event_common common;
     void *dev;
     uint8_t id;
-}; // +4
+}; // +5
 
 struct event_system_cmd {
     struct event_common common;
     char *capture;
-};
+}; // +4
 
 struct event_softcut_render {
     struct event_common common;
@@ -326,7 +323,7 @@ struct event_softcut_render {
     float start;
     size_t size;
     float* data;
-};
+}; // + 20
 
 struct event_softcut_position {
     struct event_common common;
@@ -343,34 +340,6 @@ struct event_custom {
     void *value;
     void *context;
 }; // +12
-
-struct event_screen_result_text_extents {    
-    struct event_common common;
-    // NB: cairo returns doubles;
-    // seems like overkill,
-    // but we do want to respect fractional positions (?)
-    float x_bearing;
-    float y_bearing;
-    float width;
-    float height;
-    float x_advance;
-    float y_advance;
-};
-    
-struct event_screen_result_current_point {    
-    struct event_common common;
-    float x;
-    float y;
-};
-
-    
-struct event_screen_result_peek {    
-    struct event_common common;
-    int w;
-    int h;
-    char* buf;
-};
-
 
 union event_data {
     uint32_t type;
@@ -409,7 +378,4 @@ union event_data {
     struct event_softcut_render softcut_render;
     struct event_softcut_position softcut_position;
     struct event_custom custom;
-    struct event_screen_result_text_extents screen_result_text_extents;
-    struct event_screen_result_current_point screen_result_current_point;
-    struct event_screen_result_peek screen_result_peek;
 };

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -167,7 +167,6 @@ struct event_hid_remove {
     uint32_t id;
 }; // +4
 
-/// fixme: maybe break this up into hid_key, hid_abs, &c?
 struct event_hid_event {
     struct event_common common;
     uint8_t id;
@@ -211,15 +210,15 @@ struct event_clock_resume {
     struct event_common common;
     uint32_t thread_id;
     double value;
-};
+}; // + 12
 
 struct event_clock_start {
     struct event_common common;
-};
+}; // + 0
 
 struct event_clock_stop {
     struct event_common common;
-};
+}; // + 0
 
 struct event_key {
     struct event_common common;
@@ -329,7 +328,7 @@ struct event_softcut_position {
     struct event_common common;
     int idx;
     float pos;
-};
+}; // + 8
 
 // forward declaration to hide scripting layer dependencies
 struct event_custom_ops;

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -327,16 +327,16 @@ void event_handle_pending(void) {
     union event_data *ev = NULL;
     char done = 0;
     while(!done) {    
-	pthread_mutex_lock(&evq.lock);
-	if (evq.size > 0) {     
-	    ev = evq_pop();
-	} else {
-	    done = 1;
-	    ev = NULL;
-	}
-	pthread_mutex_unlock(&evq.lock);
-	if (ev != NULL) {
-	    handle_event(ev);
-	}
+        pthread_mutex_lock(&evq.lock);
+        if (evq.size > 0) {     
+            ev = evq_pop();
+        } else {
+            done = 1;
+            ev = NULL;
+        }
+        pthread_mutex_unlock(&evq.lock);
+        if (ev != NULL) {
+            handle_event(ev);
+        }
     }
 }

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -139,13 +139,6 @@ MATRON_API void event_data_free(union event_data *ev) {
             ev->custom.ops->free(ev->custom.value, ev->custom.context);
         }
         break;
-    /* case EVENT_SCREEN_RESULTS:	 */
-    /* 	if (ev->screen_results.data != NULL) { */
-    /* 	    free(ev->screen_results.data); */
-    /* 	} */
-    case EVENT_SCREEN_RESULT_PEEK:
-        free(ev->screen_result_peek.buf);
-        break;
     }
     free(ev);
 }
@@ -313,15 +306,6 @@ static void handle_event(union event_data *ev) {
     case EVENT_SCREEN_REFRESH:
         w_handle_screen_refresh();
         break;
-    // case EVENT_SCREEN_RESULT_TEXT_EXTENTS:
-	//     w_handle_screen_result_text_extents(&ev->screen_result_text_extents);
-	//     break;
-    // case EVENT_SCREEN_RESULT_CURRENT_POINT:
-	//     w_handle_screen_result_current_point(&ev->screen_result_current_point);
-	//     break;
-    // case EVENT_SCREEN_RESULT_PEEK:
-	//     w_handle_screen_result_peek(&ev->screen_result_peek);
-	//     break;
     } /* switch */
 
     event_data_free(ev);

--- a/matron/src/hardware/screen.c
+++ b/matron/src/hardware/screen.c
@@ -141,10 +141,10 @@ void screen_text_trim(char *s, double w) {
 void screen_current_point() {
     double x, y;
     cairo_get_current_point (cr, &x, &y);
-    union event_data *ev = event_data_new(EVENT_SCREEN_RESULT_CURRENT_POINT);
-    ev->screen_result_current_point.x = x;
-    ev->screen_result_current_point.y = y;
-    screen_results_post(ev);
+    union screen_results_data *results = screen_results_data_new(SCREEN_RESULTS_CURRENT_POINT);
+    results->current_point.x = x;
+    results->current_point.y = y;
+    screen_results_post(results);
 }
 
 //-------------------------------------------------------
@@ -477,15 +477,15 @@ void screen_clear(void) {
 
 void screen_text_extents(const char *s) {
     cairo_text_extents_t extents;
-    cairo_text_extents(cr, s, &extents);    
-    union event_data *ev = event_data_new(EVENT_SCREEN_RESULT_TEXT_EXTENTS);    
-    ev->screen_result_text_extents.x_bearing = extents.x_bearing;
-    ev->screen_result_text_extents.y_bearing = extents.y_bearing;
-    ev->screen_result_text_extents.width = extents.width;
-    ev->screen_result_text_extents.height = extents.height;
-    ev->screen_result_text_extents.x_advance = extents.x_advance;
-    ev->screen_result_text_extents.y_advance = extents.y_advance;
-    screen_results_post(ev);
+    cairo_text_extents(cr, s, &extents);   
+    union screen_results_data* results = screen_results_data_new(SCREEN_RESULTS_TEXT_EXTENTS);
+    results->text_extents.x_bearing = extents.x_bearing;
+    results->text_extents.y_bearing = extents.y_bearing;
+    results->text_extents.width = extents.width;
+    results->text_extents.height = extents.height;
+    results->text_extents.x_advance = extents.x_advance;
+    results->text_extents.y_advance = extents.y_advance;
+    screen_results_post(results);
 }
 
 extern void screen_export_png(const char *s) {
@@ -571,11 +571,11 @@ void screen_peek(int x, int y, int w, int h) {
             p++;
         }
     }
-    union event_data *ev = event_data_new(EVENT_SCREEN_RESULT_PEEK);
-    ev->screen_result_peek.w = w;
-    ev->screen_result_peek.h = h;    
-    ev->screen_result_peek.buf = buf;
-    screen_results_post(ev);
+    union screen_results_data *results = screen_results_data_new(SCREEN_RESULTS_PEEK);
+    results->peek.w = w;
+    results->peek.h = h;    
+    results->peek.buf = buf;
+    screen_results_post(results);
 }
 
 void screen_poke(int x, int y, int w, int h, unsigned char *buf) {

--- a/matron/src/hardware/screen/ssd1322.c
+++ b/matron/src/hardware/screen/ssd1322.c
@@ -177,6 +177,7 @@ void ssd1322_init() {
     write_command_with_data(SSD1322_SET_VCOMH_VOLTAGE, 0x04);
     write_command(SSD1322_SET_DISPLAY_MODE_NORMAL);
 
+    // Flips the screen orientation if the device is a norns shield.
     if( platform() != PLATFORM_CM3 ){
         write_command_with_data(SSD1322_SET_DUAL_COMM_LINE_MODE, 0x04, 0x11);
     }

--- a/matron/src/main.c
+++ b/matron/src/main.c
@@ -51,6 +51,7 @@ void cleanup(void) {
     stat_deinit();
     jack_client_deinit();
     ssd1322_deinit();
+    screen_results_deinit();
     fprintf(stderr, "matron shutdown complete\n");
     exit(0);
 }
@@ -106,12 +107,10 @@ int main(int argc, char **argv) {
     fprintf(stderr, "setting cleanup...\n");
     atexit(cleanup);
 
-
     fprintf(stderr, "init input...\n");
     // start reading input to interpreter
     input_init();
 
-    
     fprintf(stderr, "running startup...\n");
     // i/o subsystems are ready; run user startup routine
     w_startup();
@@ -126,7 +125,6 @@ int main(int argc, char **argv) {
 
     fprintf(stderr, "running post-startup...\n");
     w_post_startup();
-    
     
     // blocks until quit
     event_loop();

--- a/matron/src/screen_results.c
+++ b/matron/src/screen_results.c
@@ -21,7 +21,6 @@ void screen_results_deinit() {
 }    
 
 void screen_results_wait() {
-    fprintf(stderr, "screen_results_wait\n");
     sem_wait(&sem_results);
 }
 
@@ -33,7 +32,6 @@ void screen_results_post(union screen_results_data *data) {
         screen_results_free();
     }
     results_data = data;
-    fprintf(stderr, "screen_results_post\n");
     sem_post(&sem_results);
 }
 

--- a/matron/src/screen_results.c
+++ b/matron/src/screen_results.c
@@ -35,7 +35,7 @@ void screen_results_post(union screen_results_data *data) {
     sem_post(&sem_results);
 }
 
-union screen_results_data *screen_results_data_new(screen_results_t type) { 
+union screen_results_data* screen_results_data_new(screen_results_t type) { 
     union screen_results_data *data = calloc(1, sizeof(union screen_results_data));
     data->type = type;
     return data;

--- a/matron/src/screen_results.c
+++ b/matron/src/screen_results.c
@@ -1,5 +1,6 @@
 #include <semaphore.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "events.h"
 #include "screen_results.h"
@@ -7,25 +8,58 @@
 // instead of a queue, we just have a single event here!
 // i think for the moment it is enough, 
 // since only one blocking request can be in flight at a time
-// note that we only store a pointer, 
-// and consumer must free the event data
-static union event_data* ev_result;
-static sem_t sem_result;
+static union screen_results_data* results_data;
+static sem_t sem_results;
 
 void screen_results_init() {
-    sem_init(&sem_result, 0, 0);
+    results_data = NULL;
+    sem_init(&sem_results, 0, 0);
+}    
+
+void screen_results_deinit() {
+    screen_results_free();
 }    
 
 void screen_results_wait() {
     fprintf(stderr, "screen_results_wait\n");
-    sem_wait(&sem_result);
+    sem_wait(&sem_results);
 }
 
-void screen_results_post(union event_data *ev) {
-    ev_result = ev;
+void screen_results_post(union screen_results_data *data) {
+    if (results_data != NULL) { 
+        // the old data hasn't been handled yet!
+        // this shouldn't happen
+        fprintf(stderr, "SYSTEM ERROR: screen_results_post: dropping unhandled results data!\n");
+        screen_results_free();
+    }
+    results_data = data;
     fprintf(stderr, "screen_results_post\n");
-    sem_post(&sem_result);
+    sem_post(&sem_results);
 }
-union event_data *screen_results_get() {
-    return ev_result;
+
+union screen_results_data *screen_results_data_new(screen_results_t type) { 
+    union screen_results_data *data = calloc(1, sizeof(union screen_results_data));
+    data->type = type;
+    return data;
+}
+
+// only ever frees the single item in the queue
+void screen_results_free() {
+    if (results_data != NULL) {
+        switch(results_data->type) { 
+            case SCREEN_RESULTS_TEXT_EXTENTS:
+                break;
+            case SCREEN_RESULTS_CURRENT_POINT:
+                break;
+            case SCREEN_RESULTS_PEEK:
+                free(results_data->peek.buf);
+                break;
+        }
+        free(results_data);
+        results_data = NULL;
+    }
+}
+
+union screen_results_data *screen_results_get() {
+    return results_data;
 }

--- a/matron/src/screen_results.h
+++ b/matron/src/screen_results.h
@@ -14,9 +14,8 @@ struct screen_results_common {
 
 struct screen_results_text_extents {    
     struct screen_results_common common;
-    // NB: cairo returns doubles;
-    // seems like overkill,
-    // but we do want to respect fractional positions (?)
+    // NB: cairo returns doubles,
+    // and the actual lua call uses only w/h, casting to int
     float x_bearing;
     float y_bearing;
     float width;
@@ -55,4 +54,4 @@ extern void screen_results_free();
 extern void screen_results_wait();
 extern void screen_results_post(union screen_results_data *results);
 
-extern union screen_results_data *screen_results_get();
+extern union screen_results_data* screen_results_get();

--- a/matron/src/screen_results.h
+++ b/matron/src/screen_results.h
@@ -1,8 +1,58 @@
 #pragma once
 
-#include "event_types.h"
+#include <stdint.h>
+
+typedef enum { 
+    SCREEN_RESULTS_TEXT_EXTENTS,
+    SCREEN_RESULTS_CURRENT_POINT,
+    SCREEN_RESULTS_PEEK,
+} screen_results_t;
+
+struct screen_results_common { 
+    uint32_t type;
+};
+
+struct screen_results_text_extents {    
+    struct screen_results_common common;
+    // NB: cairo returns doubles;
+    // seems like overkill,
+    // but we do want to respect fractional positions (?)
+    float x_bearing;
+    float y_bearing;
+    float width;
+    float height;
+    float x_advance;
+    float y_advance;
+};
+    
+struct screen_results_current_point {    
+    struct event_common common;
+    float x;
+    float y;
+};
+
+    
+struct screen_results_peek {    
+    struct event_common common;
+    int w;
+    int h;
+    char* buf;
+};
+
+union screen_results_data { 
+    uint32_t type;
+    struct screen_results_text_extents text_extents;
+    struct screen_results_current_point current_point;
+    struct screen_results_peek peek;
+};
 
 extern void screen_results_init();
+extern void screen_results_deinit();
+
+extern union screen_results_data* screen_results_data_new(screen_results_t type);
+extern void screen_results_free();
+
 extern void screen_results_wait();
-extern void screen_results_post(union event_data *ev);
-extern union event_data *screen_results_get();
+extern void screen_results_post(union screen_results_data *results);
+
+extern union screen_results_data *screen_results_get();

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1038,20 +1038,19 @@ int _screen_text_extents(lua_State *l) {
     fprintf(stderr, "text_extents, waiting on results\n");
     screen_results_wait();
     fprintf(stderr, "text_extents, got screen results\n");
-    union event_data *ev = screen_results_get();
-    struct event_screen_result_text_extents *ext = (struct event_screen_result_text_extents *)ev;
+    union screen_results_data *data = screen_results_get();
 #if 1 // legacy API
-    lua_pushinteger(l, (int)ext->width);
-    lua_pushinteger(l, (int)ext->height);
-    event_data_free(ev);
+    lua_pushinteger(l, (int)data->text_extents.width);
+    lua_pushinteger(l, (int)data->text_extents.height);
+    screen_results_free();
     return 2;
 #else
-    lua_pushnumber(l, ext->x_bearing);
-    lua_pushnumber(l, ext->y_bearing);
-    lua_pushnumber(l, ext->width);
-    lua_pushnumber(l, ext->height);
-    lua_pushnumber(l, ext->x_advance);
-    lua_pushnumber(l, ext->y_advance);
+    lua_pushnumber(l, data->text_extents.x_bearing);
+    lua_pushnumber(l, data->text_extents.y_bearing);
+    lua_pushnumber(l, data->text_extents.width);
+    lua_pushnumber(l, data->text_extents.height);
+    lua_pushnumber(l, data->text_extents.x_advance);
+    lua_pushnumber(l, data->text_extents.y_advance);
     event_data_free(ev);
     return 6;
 #endif
@@ -1122,12 +1121,11 @@ int _screen_peek(lua_State *l) {
      && (h > 0)) {
         screen_event_peek(x, y, w, h);
         screen_results_wait();
-        union event_data *ev = screen_results_get();
-        struct event_screen_result_peek *peek = (struct event_screen_result_peek *)ev;
-        lua_pushinteger(l, peek->w);
-        lua_pushinteger(l, peek->h);
-        lua_pushstring(l, peek->buf);
-        event_data_free(ev);
+        union screen_results_data *results = screen_results_get();
+        lua_pushinteger(l, results->peek.w);
+        lua_pushinteger(l, results->peek.h);
+        lua_pushstring(l, results->peek.buf);
+        screen_results_free();
     } else { 
         lua_pushinteger(l, 0);
         lua_pushinteger(l, 0);
@@ -1427,11 +1425,10 @@ int _screen_current_point(lua_State *l) {
     lua_settop(l, 0);
     screen_event_current_point();
     screen_results_wait();
-    union event_data *ev = screen_results_get();
-    struct event_screen_result_current_point *p = (struct event_screen_result_current_point *)ev;
-    lua_pushnumber(l, p->x);
-    lua_pushnumber(l, p->y);
-    event_data_free(ev);
+    union screen_results_data *results = screen_results_get();
+    lua_pushnumber(l, results->current_point.x);
+    lua_pushnumber(l, results->current_point.y);
+    screen_results_free();
     return 2;
 }
 

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1035,9 +1035,7 @@ int _screen_text_extents(lua_State *l) {
     const char *s = luaL_checkstring(l, 1);
     
     screen_event_text_extents(s);
-    fprintf(stderr, "text_extents, waiting on results\n");
     screen_results_wait();
-    fprintf(stderr, "text_extents, got screen results\n");
     union screen_results_data *data = screen_results_get();
 #if 1 // legacy API
     lua_pushinteger(l, (int)data->text_extents.width);


### PR DESCRIPTION
- add a `deinit` called from main cleanup

- move screen result data definitions out of `event_types`

- other minor cleanups along the way

- fix endless silly typos in screen.lua, apparently